### PR TITLE
updateArticle() shouldn't require article body unless it has to be updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,12 +63,12 @@ module.exports = function (config) {
       assert(typeof cb === 'function', 'cb required');
       assert(typeof opts.articleId === 'string', 'opts.articleId required');
       assert(typeof opts.revision === 'string', 'opts.revision required');
-      assert(Object(opts.article) === opts.article, 'opts.article required');
+      var article = opts.article || null;
       var articleId = opts.articleId;
       var bundleFiles = opts.bundleFiles || [];
       var meta = articleMetadataFromOpts(opts);
       meta.revision = opts.revision;
-      var fd = createArticleUploadFormData(opts.article, bundleFiles, meta);
+      var fd = createArticleUploadFormData(article, bundleFiles, meta);
 
       makeRequest('POST', '/articles/' + articleId, {
         formData: fd

--- a/lib/create-article-upload-form-data.js
+++ b/lib/create-article-upload-form-data.js
@@ -7,16 +7,7 @@ module.exports = function createArticleUploadFormData (article, bundleFiles, met
   assert(typeof bundleFiles['article.json'] === 'undefined', 'bundle cannot contain article.json file');
   assert(typeof bundleFiles['metadata'] === 'undefined', 'bundle cannot contain metadata file');
   metadata = metadata || {};
-  var articleJson = JSON.stringify(article);
   var result = [{
-    name: 'article.json',
-    filename: 'article.json',
-    value: articleJson,
-    options: {
-      filename: 'article.json',
-      contentType: 'application/json'
-    }
-  }, {
     name: 'metadata',
     value: JSON.stringify({ data: metadata }),
     options: {
@@ -24,6 +15,19 @@ module.exports = function createArticleUploadFormData (article, bundleFiles, met
       contentType: 'application/json'
     }
   }];
+
+  if (article) {
+	  var articleJson = JSON.stringify(article);
+	  result.push({
+	    name: 'article.json',
+	    filename: 'article.json',
+	    value: articleJson,
+	    options: {
+	      filename: 'article.json',
+	      contentType: 'application/json'
+	    }
+	});
+  }
 
   Object.keys(bundleFiles).forEach(function (name, index) {
     var url = bundleFiles[name];


### PR DESCRIPTION
The updateArticle API endpoint does not require article body to be passed, unless there are changes. You can use the endpoint to update metadata fields only.