### PR TITLE
Add support for undocumented metadata fields

### DIFF
--- a/lib/article-metadata-from-opts.js
+++ b/lib/article-metadata-from-opts.js
@@ -5,6 +5,9 @@ var assert = require('assert');
 module.exports = function articleMetadataFromOpts (opts) {
   assert(typeof opts.isPreview === 'undefined' || typeof opts.isPreview === 'boolean');
   assert(typeof opts.isSponsored === 'undefined' || typeof opts.isSponsored === 'boolean');
+  assert(typeof opts.accessoryText === 'undefined' || typeof opts.accessoryText === 'string');
+  assert(typeof opts.isCandidateToBeFeatured === 'undefined' || typeof opts.isCandidateToBeFeatured === 'boolean');
+  assert(typeof opts.isDevelopingStory === 'undefined' || typeof opts.isDevelopingStory === 'boolean');
 
   var obj = {
     isPreview: typeof opts.isPreview === 'boolean' ? opts.isPreview : true,
@@ -13,6 +16,18 @@ module.exports = function articleMetadataFromOpts (opts) {
 
   if (opts.sections && opts.sections.length > 0) {
     obj.links = { sections: opts.sections };
+  }
+
+  if (opts.accessoryText && opts.accessoryText.length > 0) {
+	  obj.accessoryText = opts.accessoryText;
+  }
+
+  if (opts.isCandidateToBeFeatured) {
+	  obj.isCandidateToBeFeatured = !!opts.isCandidateToBeFeatured;
+  }
+
+  if (opts.isDevelopingStory) {
+	  obj.isDevelopingStory = !!opts.isDevelopingStory;
   }
 
   return obj;


### PR DESCRIPTION
Add support for `accessoryText` field, and undocumented `isCandidateToBeFeatured`, and `isDevelopingStory` metadata fields. 

`isCandidateToBeFeatured` is a deprecated, but still in use field that can suggest Apple News app how to layout particular article in the feed.

`isDevelopingStory` disables cache for the user that has open the story, so if it updates, they can see changes faster. 
