### PR TITLE
Make client.createArticle description more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var client = createClient({
 client.readChannel ({ channelId }, cb)
 client.listSections ({ channelId }, cb)
 client.readSection ({ sectionId }, cb)
-client.createArticle ({ channelId, article }, cb)
+client.createArticle ({ channelId, article, bundleFiles, isPreview = true }, cb)
 client.readArticle ({ articleId }, cb)
 client.updateArticle ({ articleId, revision, article }, cb)
 client.deleteArticle ({ articleId }, cb)


### PR DESCRIPTION
I had to open up the code and check around to see why my article was always being sent as a preview; thought it would be clearer and easier for others to use if we specified that param in the docs.

@iefserge, @kesla, @micnews/engineers 