### PR TITLE
Upgrade request, switch out async for eachy

### DIFF
--- a/lib/encode-form-data.js
+++ b/lib/encode-form-data.js
@@ -3,7 +3,7 @@
 var FormData = require('form-data');
 var stream = require('stream');
 var request = require('request');
-var async = require('async');
+var seriesEach = require('eachy');
 var fileType = require('file-type');
 var objectAssign = require('object-assign');
 
@@ -33,7 +33,7 @@ function append (form, item, data, contentType) {
 module.exports = function encodeFormData (formData, cb) {
   var form = new FormData();
 
-  async.mapSeries(formData, function (item, callback) {
+  seriesEach(formData, function (item, callback) {
     var value = item.value;
     var options = item.options;
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/micnews/apple-news#readme",
   "devDependencies": {
+    "async": "^2.5.0",
     "nyc": "^8.3.0",
     "pem": "^1.8.1",
     "semistandard": "^9.0.0",
@@ -26,11 +27,11 @@
     "tape": "^4.5.1"
   },
   "dependencies": {
-    "async": "^2.0.0-rc.3",
+    "eachy": "^1.0.5",
     "file-type": "^3.8.0",
     "form-data": "^2.0.0",
     "moment": "^2.12.0",
     "object-assign": "^4.0.1",
-    "request": "^2.70.0"
+    "request": "^2.81.0"
   }
 }


### PR DESCRIPTION
Thanks for the project! Just two things in this pull request
- upgrade request as it included an old version of `ajv` which caused some webpack warnings
- switch out `async` for `eachy`. Currently trying to slim down a project that depends on this and it would be nice not to pull in all of `async` just for a single call.