### PR TITLE
Add `maturityRating` to article meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 API wrapper module for Apple News API https://developer.apple.com/library/ios/documentation/General/Conceptual/News_API_Ref/index.html
 
-For Node versions < 4, use `apple-news@^1`. For Node versions >= 4 use `apple-news@^2`
+Supports creating, reading, updating, deleting, and searching articles.
+Also supports reading and listing sections, as well as reading channels!
+
+**For Node versions < 4, use `apple-news@^1`. For Node versions >= 4 use `apple-news@^2`**
 
 ## Install
 

--- a/lib/article-metadata-from-opts.js
+++ b/lib/article-metadata-from-opts.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 module.exports = function articleMetadataFromOpts (opts) {
   assert(typeof opts.isPreview === 'undefined' || typeof opts.isPreview === 'boolean');
   assert(typeof opts.isSponsored === 'undefined' || typeof opts.isSponsored === 'boolean');
+  assert(typeof opts.maturityRating === 'undefined' || typeof opts.maturityRating === 'string');
 
   const obj = {
     isPreview: typeof opts.isPreview === 'boolean' ? opts.isPreview : true,
@@ -13,6 +14,10 @@ module.exports = function articleMetadataFromOpts (opts) {
 
   if (opts.sections && opts.sections.length > 0) {
     obj.links = { sections: opts.sections };
+  }
+
+  if (opts.maturityRating) {
+    obj.maturityRating = opts.maturityRating;
   }
 
   return obj;

--- a/test/article-metadata-from-opts.test.js
+++ b/test/article-metadata-from-opts.test.js
@@ -1,5 +1,5 @@
-var test = require('tape');
-var articleMetadataFromOpts = require('../lib/article-metadata-from-opts.js');
+const test = require('tape');
+const articleMetadataFromOpts = require('../lib/article-metadata-from-opts.js');
 
 test('articleMetadataFromOpts()', function (t) {
   t.is(
@@ -71,14 +71,14 @@ test('articleMetadataFromOpts()', function (t) {
     'it does not return a maturityRating property when maturityRating has not been supplied'
   );
 
-  var sections = ['foo', 'bar', 'baz'];
+  const sections = ['foo', 'bar', 'baz'];
   t.deepEqual(
     articleMetadataFromOpts({ sections: sections }).links.sections,
     sections,
     'it sets links.sections to the supplied sections array'
   );
 
-  var maturityRating = 'foobar';
+  const maturityRating = 'foobar';
   t.is(
     articleMetadataFromOpts({ maturityRating: maturityRating }).maturityRating,
     maturityRating,

--- a/test/article-metadata-from-opts.test.js
+++ b/test/article-metadata-from-opts.test.js
@@ -8,5 +8,54 @@ test('articleMetadataFromOpts()', function (t) {
     'it is a function'
   );
 
+  t.is(
+    articleMetadataFromOpts({ isPreview: true }).isPreview,
+    true,
+    'it returns isPreview=true when opts.isPreview is true'
+  );
+
+  t.is(
+    articleMetadataFromOpts({ isPreview: false }).isPreview,
+    false,
+    'it returns isPreview=false when opts.isPreview is false'
+  );
+
+  t.is(
+    articleMetadataFromOpts({}).isPreview,
+    true,
+    'it returns isPreview=true when opts.isPreview is missing'
+  );
+
+  t.is(
+    articleMetadataFromOpts({ isSponsored: true }).isSponsored,
+    true,
+    'it returns isSponsored=true when opts.isSponsored is true'
+  );
+
+  t.is(
+    articleMetadataFromOpts({ isSponsored: false }).isSponsored,
+    false,
+    'it returns isSponsored=false when opts.isSponsored is false'
+  );
+
+  t.is(
+    articleMetadataFromOpts({}).isSponsored,
+    false,
+    'it returns isSponsored=false when opts.isSponsored is missing'
+  );
+
+  t.is(
+    articleMetadataFromOpts({}).sections,
+    undefined,
+    'it does not return a sections property when sections have not been supplied'
+  );
+
+  const sections = ['foo', 'bar', 'baz'];
+  t.deepEqual(
+    articleMetadataFromOpts({ sections: sections }).links.sections,
+    sections,
+    'it sets links.sections to the supplied sections array'
+  );
+
   t.end();
 });

--- a/test/article-metadata-from-opts.test.js
+++ b/test/article-metadata-from-opts.test.js
@@ -50,11 +50,24 @@ test('articleMetadataFromOpts()', function (t) {
     'it does not return a sections property when sections have not been supplied'
   );
 
+  t.is(
+    articleMetadataFromOpts({}).maturityRating,
+    undefined,
+    'it does not return a maturityRating property when maturityRating has not been supplied'
+  );
+
   const sections = ['foo', 'bar', 'baz'];
   t.deepEqual(
     articleMetadataFromOpts({ sections: sections }).links.sections,
     sections,
     'it sets links.sections to the supplied sections array'
+  );
+
+  const maturityRating = 'foobar';
+  t.is(
+    articleMetadataFromOpts({ maturityRating: maturityRating }).maturityRating,
+    maturityRating,
+    'it sets maturityRating to the supplied maturity rating'
   );
 
   t.end();

--- a/test/article-metadata-from-opts.test.js
+++ b/test/article-metadata-from-opts.test.js
@@ -8,6 +8,21 @@ test('articleMetadataFromOpts()', function (t) {
     'it is a function'
   );
 
+  t.throws(
+    function () { articleMetadataFromOpts({ isPreview: 'foo' }); },
+    'it throws if isPreview is not a boolean'
+  );
+
+  t.throws(
+    function () { articleMetadataFromOpts({ isSponsored: 'foo' }); },
+    'it throws if isSponsored is not a boolean'
+  );
+
+  t.throws(
+    function () { articleMetadataFromOpts({ maturityRating: 1 }); },
+    'it throws if maturityRating is not a string'
+  );
+
   t.is(
     articleMetadataFromOpts({ isPreview: true }).isPreview,
     true,

--- a/test/article-metadata-from-opts.test.js
+++ b/test/article-metadata-from-opts.test.js
@@ -1,0 +1,12 @@
+var test = require('tape');
+var articleMetadataFromOpts = require('../lib/article-metadata-from-opts.js');
+
+test('articleMetadataFromOpts()', function (t) {
+  t.is(
+    typeof articleMetadataFromOpts,
+    'function',
+    'it is a function'
+  );
+
+  t.end();
+});

--- a/test/article-metadata-from-opts.test.js
+++ b/test/article-metadata-from-opts.test.js
@@ -71,14 +71,14 @@ test('articleMetadataFromOpts()', function (t) {
     'it does not return a maturityRating property when maturityRating has not been supplied'
   );
 
-  const sections = ['foo', 'bar', 'baz'];
+  var sections = ['foo', 'bar', 'baz'];
   t.deepEqual(
     articleMetadataFromOpts({ sections: sections }).links.sections,
     sections,
     'it sets links.sections to the supplied sections array'
   );
 
-  const maturityRating = 'foobar';
+  var maturityRating = 'foobar';
   t.is(
     articleMetadataFromOpts({ maturityRating: maturityRating }).maturityRating,
     maturityRating,

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 process.env.NODE_ENV = 'test';
+require('./article-metadata-from-opts.test.js');
 const createClient = require('../');
 const article = require('./article.json');
 const channelId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';


### PR DESCRIPTION
This PR does a couple of things:

* Allows a user to pass in a `maturityRating` string to be delivered with the article data to Apple.
* Adds tests for existing features of `articleMetadataFromOpts`.
* Adds `package-lock.json` to `.gitignore`