### PR TITLE
Change isPreview default to false

### DIFF
--- a/lib/article-metadata-from-opts.js
+++ b/lib/article-metadata-from-opts.js
@@ -8,7 +8,7 @@ module.exports = function articleMetadataFromOpts (opts) {
   assert(typeof opts.maturityRating === 'undefined' || typeof opts.maturityRating === 'string');
 
   const obj = {
-    isPreview: typeof opts.isPreview === 'boolean' ? opts.isPreview : true,
+    isPreview: typeof opts.isPreview === 'boolean' ? opts.isPreview : false,
     isSponsored: !!opts.isSponsored
   };
 

--- a/test/article-metadata-from-opts.test.js
+++ b/test/article-metadata-from-opts.test.js
@@ -37,8 +37,8 @@ test('articleMetadataFromOpts()', function (t) {
 
   t.is(
     articleMetadataFromOpts({}).isPreview,
-    true,
-    'it returns isPreview=true when opts.isPreview is missing'
+    false,
+    'it returns isPreview=false when opts.isPreview is missing'
   );
 
   t.is(


### PR DESCRIPTION
The default state for `isPreview` per the documentation is `false`:

- https://developer.apple.com/documentation/apple_news/create_article_metadata_fields
- https://developer.apple.com/documentation/apple_news/update_article_metadata_fields

This caused us a little bit of confusion when trying to work out why our articles were updating in a draft state. For consistency, it seems to make sense that the default here matches the documentation.