### PR TITLE
Update apple news article with isHidden property

### DIFF
--- a/lib/article-metadata-from-opts.js
+++ b/lib/article-metadata-from-opts.js
@@ -9,7 +9,7 @@ module.exports = function articleMetadataFromOpts (opts) {
   assert(typeof opts.isHidden === 'undefined' || typeof opts.isHidden === 'boolean');
 
   const obj = {
-    isPreview: typeof opts.isPreview === 'boolean' ? opts.isPreview : true,
+    isPreview: typeof opts.isPreview === 'boolean' ? opts.isPreview : false,
     isSponsored: !!opts.isSponsored,
     isHidden: typeof opts.isHidden === 'boolean' ? opts.isHidden : false
   };

--- a/lib/article-metadata-from-opts.js
+++ b/lib/article-metadata-from-opts.js
@@ -6,10 +6,12 @@ module.exports = function articleMetadataFromOpts (opts) {
   assert(typeof opts.isPreview === 'undefined' || typeof opts.isPreview === 'boolean');
   assert(typeof opts.isSponsored === 'undefined' || typeof opts.isSponsored === 'boolean');
   assert(typeof opts.maturityRating === 'undefined' || typeof opts.maturityRating === 'string');
+  assert(typeof opts.isHidden === 'undefined' || typeof opts.isHidden === 'boolean');
 
   const obj = {
     isPreview: typeof opts.isPreview === 'boolean' ? opts.isPreview : true,
-    isSponsored: !!opts.isSponsored
+    isSponsored: !!opts.isSponsored,
+    isHidden: opts.isHidden
   };
 
   if (opts.sections && opts.sections.length > 0) {

--- a/lib/article-metadata-from-opts.js
+++ b/lib/article-metadata-from-opts.js
@@ -11,7 +11,7 @@ module.exports = function articleMetadataFromOpts (opts) {
   const obj = {
     isPreview: typeof opts.isPreview === 'boolean' ? opts.isPreview : true,
     isSponsored: !!opts.isSponsored,
-    isHidden: opts.isHidden
+    isHidden: typeof opts.isHidden === 'boolean' ? opts.isHidden : false
   };
 
   if (opts.sections && opts.sections.length > 0) {


### PR DESCRIPTION
Updated articleMetadataFromOpts for supporting isHidden property 

We will get an error code NOT_ALLOWED while trying to change isPreview flag from false to true.
Once an article has been published with **_isPreview_** set to false, the setting cannot be changed to true. 

We could use **isHidden** property to temporarily keeping the article as hidden. We could make use of the update operation with isHidden set to true.
**isHidden**  - Boolean that indicates whether the article should be temporarily hidden from display in the News feed. Note that a hidden article is accessible if you have a direct link to the article.
Default: false

Further reference:-
https://developer.apple.com/documentation/apple_news/update_an_article
https://developer.apple.com/documentation/apple_news/delete_an_article